### PR TITLE
Revert "Improve conformance testing of exponential-backoff-fn"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [clojure.java-time "0.3.0"]
                  [slingshot "0.12.2"]]
-  :profiles {:dev {:dependencies [[circleci/bond "0.3.0"]
-                                  [org.clojure/test.check "1.1.0"]]
+  :profiles {:dev {:dependencies [[circleci/bond "0.3.0"]]
                    :exclusions [org.clojure/clojurescript
                                 com.cemerick/clojurescript.test]}}
 

--- a/src/circle/wait_for8.clj
+++ b/src/circle/wait_for8.clj
@@ -126,8 +126,7 @@
                        :f f})
           (throw+))))))
 
-(s/def ::sleep-fn (s/fspec :args (s/cat) :ret (complement neg?)))
-(s/def ::sleep (s/nilable (s/or :d time/duration? :f ::sleep-fn)))
+(s/def ::sleep (s/nilable (s/or :d time/duration? :f fn?)))
 (s/def ::tries (s/or :int nat-int? :unlimited #{:unlimited}))
 (s/def ::timeout time/duration?)
 (s/def ::slingshot-tuple (s/tuple keyword? any?))

--- a/test/circle/wait_for8_test.clj
+++ b/test/circle/wait_for8_test.clj
@@ -241,8 +241,10 @@
       (is (= 1 (-> foo bond/calls count))))))
 
 (deftest backoff-fn
-  (testing "conforms to spec"
-    (is (stest/check-fn ::sleep-fn (exponential-backoff-fn))))
+  (testing "never-negative"
+    (is (every? (complement neg?) (take 50 (repeatedly (exponential-backoff-fn {:seed 123 ;; will generate a jitter value > 10
+                                                                                :base (time/millis 10)
+                                                                                :jitter (time/millis 1000)}))))))
   (testing "growing"
     (let [xs (take 50 (repeatedly (exponential-backoff-fn {:seed 123
                                                            :base (time/millis 1000)


### PR DESCRIPTION
This reverts commit 10ed1c3590803e72a9c19e2f5f17fb4e2800e29e.

It turns out that the call the (s/valid? ...) at the beginning of
wait-for causing the impure function created
by (exponential-backoff-fn) to be called multiple times in a
generative testing fashion, which means that when it is called 'for
real' the timeout is already too large.